### PR TITLE
feat: add GetAllFollowing method to fetch user's following list

### DIFF
--- a/get_following.go
+++ b/get_following.go
@@ -1,0 +1,54 @@
+package farcaster
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// GetAllFollowing gets all users that a given FID is following
+// If fid is nil, it gets the following list for the authenticated user
+func (w *Warpcast) GetAllFollowing(fid *int) (*UsersResult, error) {
+	var users []ApiUser
+	var cursor *string
+	limit := 100
+
+	// If fid is nil, get the authenticated user's FID
+	if fid == nil {
+		me, err := w.GetMe()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get authenticated user: %w", err)
+		}
+		fid = &me.Fid
+	}
+
+	for {
+		params := map[string]string{
+			"fid":   fmt.Sprintf("%d", *fid),
+			"limit": fmt.Sprintf("%d", limit),
+		}
+		if cursor != nil {
+			params["cursor"] = *cursor
+		}
+
+		resp, err := w.request("GET", "following", params, nil, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get following: %w", err)
+		}
+
+		var response FollowingGetResponse
+		if err := json.Unmarshal(resp, &response); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal following response: %w", err)
+		}
+
+		if len(response.Result.Users) > 0 {
+			users = append(users, response.Result.Users...)
+		}
+
+		if response.Next == nil {
+			break
+		}
+		cursor = &response.Next.Cursor
+	}
+
+	return &UsersResult{Users: users}, nil
+} 

--- a/main.go
+++ b/main.go
@@ -371,3 +371,23 @@ func (w *Warpcast) GetCast(hash string) (*CastContent, error) {
 
 	return &result.Result, nil
 }
+
+// GetMe retrieves the authenticated user's information
+func (w *Warpcast) GetMe() (*ApiUser, error) {
+	resp, err := w.request("GET", "me", nil, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user info: %w", err)
+	}
+
+	var result struct {
+		Result ApiUser `json:"result"`
+	}
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal user response: %w", err)
+	}
+
+	return &result.Result, nil
+}
+
+
+</```rewritten_file>

--- a/types.go
+++ b/types.go
@@ -107,3 +107,18 @@ type CastsPostRequest struct {
 type CastsPostResponse struct {
 	Result CastContent `json:"result"`
 }
+
+// Add these new types to types.go
+
+type UsersResult struct {
+	Users []ApiUser `json:"users"`
+}
+
+type FollowingGetResponse struct {
+	Result struct {
+		Users []ApiUser `json:"users"`
+	} `json:"result"`
+	Next *struct {
+		Cursor string `json:"cursor"`
+	} `json:"next"`
+}


### PR DESCRIPTION
- Add GetAllFollowing method to fetch all users that a given FID is following
- Add GetMe method to fetch authenticated user's information
- Add necessary types for user and following responses
- Support pagination through cursor-based iteration
- Handle optional FID parameter defaulting to authenticated user

This enables fetching complete following lists for any user or the authenticated user.